### PR TITLE
feat: flush queue

### DIFF
--- a/controllers/queueController.js
+++ b/controllers/queueController.js
@@ -57,5 +57,18 @@ class JobQueueController {
 			return;
 		}
 	};
+
+	flushQueue = async (req, res, next) => {
+		try {
+			const result = await this.jobQueue.flushQueue();
+			return res.success({
+				msg: this.stringService.jobQueueFlush,
+				data: result,
+			});
+		} catch (error) {
+			next(handleError(error, SERVICE_NAME, "flushQueue"));
+			return;
+		}
+	};
 }
 export default JobQueueController;

--- a/controllers/queueController.js
+++ b/controllers/queueController.js
@@ -70,5 +70,18 @@ class JobQueueController {
 			return;
 		}
 	};
+
+	checkQueueHealth = async (req, res, next) => {
+		try {
+			const stuckQueues = await this.jobQueue.checkQueueHealth();
+			return res.success({
+				msg: this.stringService.queueHealthCheck,
+				data: stuckQueues,
+			});
+		} catch (error) {
+			next(handleError(error, SERVICE_NAME, "checkQueueHealth"));
+			return;
+		}
+	};
 }
 export default JobQueueController;

--- a/index.js
+++ b/index.js
@@ -106,23 +106,13 @@ const shutdown = async () => {
 			service: SERVICE_NAME,
 			method: "shutdown",
 		});
-		// flush Redis
-		const settings =
-			ServiceRegistry.get(SettingsService.SERVICE_NAME).getSettings() || {};
-
-		const { redisHost = "127.0.0.1", redisPort = 6379 } = settings;
-		const redis = new IORedis({
-			host: redisHost,
-			port: redisPort,
-		});
-		logger.info({ message: "Flushing Redis" });
-		await redis.flushall();
-		logger.info({ message: "Redis flushed" });
+		await ServiceRegistry.get(JobQueue.SERVICE_NAME).flushQueue();
 		process.exit(1);
 	}, SHUTDOWN_TIMEOUT);
 	try {
 		server.close();
 		await ServiceRegistry.get(JobQueue.SERVICE_NAME).obliterate();
+		await ServiceRegistry.get(JobQueue.SERVICE_NAME).flushQueue();
 		await ServiceRegistry.get(MongoDB.SERVICE_NAME).disconnect();
 		logger.info({ message: "Graceful shutdown complete" });
 		process.exit(0);

--- a/routes/queueRoute.js
+++ b/routes/queueRoute.js
@@ -11,6 +11,7 @@ class QueueRoutes {
 		this.router.get("/jobs", this.queueController.getJobs);
 		this.router.post("/jobs", this.queueController.addJob);
 		this.router.post("/obliterate", this.queueController.obliterateQueue);
+		this.router.post("/flush", this.queueController.flushQueue);
 	}
 
 	getRouter() {

--- a/routes/queueRoute.js
+++ b/routes/queueRoute.js
@@ -12,6 +12,7 @@ class QueueRoutes {
 		this.router.post("/jobs", this.queueController.addJob);
 		this.router.post("/obliterate", this.queueController.obliterateQueue);
 		this.router.post("/flush", this.queueController.flushQueue);
+		this.router.get("/health", this.queueController.checkQueueHealth);
 	}
 
 	getRouter() {

--- a/routes/queueRoute.js
+++ b/routes/queueRoute.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-
+import { isAllowed } from "../middleware/isAllowed.js";
 class QueueRoutes {
 	constructor(queueController) {
 		this.router = Router();
@@ -7,12 +7,41 @@ class QueueRoutes {
 		this.initRoutes();
 	}
 	initRoutes() {
-		this.router.get("/metrics", this.queueController.getMetrics);
-		this.router.get("/jobs", this.queueController.getJobs);
-		this.router.post("/jobs", this.queueController.addJob);
-		this.router.post("/obliterate", this.queueController.obliterateQueue);
-		this.router.post("/flush", this.queueController.flushQueue);
-		this.router.get("/health", this.queueController.checkQueueHealth);
+		this.router.get(
+			"/metrics",
+			isAllowed(["admin", "superadmin"]),
+			this.queueController.getMetrics
+		);
+
+		this.router.get(
+			"/jobs",
+			isAllowed(["admin", "superadmin"]),
+			this.queueController.getJobs
+		);
+
+		this.router.post(
+			"/jobs",
+			isAllowed(["admin", "superadmin"]),
+			this.queueController.addJob
+		);
+
+		this.router.post(
+			"/obliterate",
+			isAllowed(["admin", "superadmin"]),
+			this.queueController.obliterateQueue
+		);
+
+		this.router.post(
+			"/flush",
+			isAllowed(["admin", "superadmin"]),
+			this.queueController.flushQueue
+		);
+
+		this.router.get(
+			"/health",
+			isAllowed(["admin", "superadmin"]),
+			this.queueController.checkQueueHealth
+		);
 	}
 
 	getRouter() {

--- a/service/jobQueue.js
+++ b/service/jobQueue.js
@@ -1,5 +1,7 @@
 import IORedis from "ioredis";
 
+const HEALTH_CHECK_INTERVAL = 15 * 60 * 1000;
+
 const QUEUE_NAMES = ["uptime", "pagespeed", "hardware", "distributed"];
 const SERVICE_NAME = "JobQueue";
 const JOBS_PER_WORKER = 5;
@@ -38,6 +40,7 @@ class NewJobQueue {
 
 		this.queues = {};
 		this.workers = {};
+		this.lastJobProcessedTime = {};
 
 		this.connection = redisConnection;
 		this.db = db;
@@ -53,6 +56,19 @@ class NewJobQueue {
 			this.queues[name] = new Queue(name, redisConnection);
 			this.workers[name] = [];
 		});
+
+		// Periodic health check
+		this.healthCheckInterval = setInterval(async () => {
+			const health = await this.checkQueueHealth();
+			if (health.stuck) {
+				this.logger.error({
+					message: `Queue is stuck: ${health.stuckQueues.join(", ")}`,
+					service: SERVICE_NAME,
+					method: "healthCheckInterval",
+				});
+				this.flushQueue();
+			}
+		}, HEALTH_CHECK_INTERVAL);
 	}
 
 	/**
@@ -149,6 +165,8 @@ class NewJobQueue {
 	createJobHandler() {
 		return async (job) => {
 			try {
+				// Set the last job processed time for this queue
+				this.lastJobProcessedTime[job.queue.name] = Date.now();
 				// Get all maintenance windows for this monitor
 				await job.updateProgress(0);
 				const monitorId = job.data._id;
@@ -558,6 +576,12 @@ class NewJobQueue {
 				service: SERVICE_NAME,
 				method: "obliterate",
 			});
+
+			if (this.healthCheckInterval) {
+				clearInterval(this.healthCheckInterval);
+				this.healthCheckInterval = null;
+			}
+
 			await Promise.all(
 				QUEUE_NAMES.map(async (name) => {
 					const queue = this.queues[name];
@@ -596,6 +620,7 @@ class NewJobQueue {
 				method: "obliterate",
 				details: metrics,
 			});
+
 			return true;
 		} catch (error) {
 			error.service === undefined ? (error.service = SERVICE_NAME) : null;
@@ -631,6 +656,68 @@ class NewJobQueue {
 		} catch (error) {
 			error.service === undefined ? (error.service = SERVICE_NAME) : null;
 			error.method === undefined ? (error.method = "getKeyValuePairs") : null;
+			throw error;
+		}
+	}
+
+	/**
+	 * Gets metrics for a specific queue
+	 * @async
+	 * @function getQueueHealthMetrics
+	 * @param {Queue} queue - The queue to get metrics for
+	 * @returns {Promise<Object>} Queue metrics
+	 */
+	async getQueueHealthMetrics(queue) {
+		const [waiting, active, completed, failed, delayed] = await Promise.all([
+			queue.getWaitingCount(),
+			queue.getActiveCount(),
+			queue.getCompletedCount(),
+			queue.getFailedCount(),
+			queue.getDelayedCount(),
+		]);
+
+		return { waiting, active, completed, failed, delayed };
+	}
+
+	getQueueIdleTimes() {
+		const now = Date.now();
+		const idleTimes = {};
+		Object.entries(this.lastJobProcessedTime).forEach(([queueName, lastProcessed]) => {
+			idleTimes[queueName] = now - lastProcessed;
+		});
+		return idleTimes;
+	}
+	async checkQueueHealth() {
+		try {
+			const currentTime = Date.now();
+			const stuckQueues = [];
+			for (const queueName of QUEUE_NAMES) {
+				const queue = this.queues[queueName];
+				const healthMetrics = await this.getQueueHealthMetrics(queue);
+				const hasJobs =
+					healthMetrics.waiting > 0 ||
+					healthMetrics.active > 0 ||
+					healthMetrics.delayed > 0 ||
+					healthMetrics.completed > 0 ||
+					healthMetrics.failed > 0;
+				const timeSinceLastProcessed = currentTime - this.lastJobProcessedTime[queueName];
+				const isStuck = hasJobs && timeSinceLastProcessed > HEALTH_CHECK_INTERVAL;
+				if (isStuck) {
+					stuckQueues.push(queueName);
+				}
+			}
+
+			if (stuckQueues.length > 0) {
+				return {
+					stuck: true,
+					stuckQueues,
+					idleTimes: this.getQueueIdleTimes(),
+				};
+			}
+			return { stuck: false, stuckQueues, idleTimes: this.getQueueIdleTimes() };
+		} catch (error) {
+			error.service === undefined ? (error.service = SERVICE_NAME) : null;
+			error.method === undefined ? (error.method = "checkQueueHealth") : null;
 			throw error;
 		}
 	}

--- a/service/jobQueue.js
+++ b/service/jobQueue.js
@@ -59,14 +59,23 @@ class NewJobQueue {
 
 		// Periodic health check
 		this.healthCheckInterval = setInterval(async () => {
-			const health = await this.checkQueueHealth();
-			if (health.stuck) {
+			try {
+				const health = await this.checkQueueHealth();
+				if (health.stuck) {
+					this.logger.error({
+						message: `Queue is stuck: ${health.stuckQueues.join(", ")}`,
+						service: SERVICE_NAME,
+						method: "healthCheckInterval",
+					});
+					this.flushQueue();
+				}
+			} catch (error) {
 				this.logger.error({
-					message: `Queue is stuck: ${health.stuckQueues.join(", ")}`,
+					message: error.message,
 					service: SERVICE_NAME,
-					method: "healthCheckInterval",
+					method: "periodicHealthCheck",
+					stack: error.stack,
 				});
-				this.flushQueue();
 			}
 		}, HEALTH_CHECK_INTERVAL);
 	}

--- a/service/jobQueue.js
+++ b/service/jobQueue.js
@@ -67,7 +67,7 @@ class NewJobQueue {
 						service: SERVICE_NAME,
 						method: "healthCheckInterval",
 					});
-					this.flushQueue();
+					await this.flushQueue();
 				}
 			} catch (error) {
 				this.logger.error({

--- a/service/stringService.js
+++ b/service/stringService.js
@@ -1,388 +1,397 @@
 class StringService {
-  static SERVICE_NAME = "StringService";
-
-  constructor(translationService) {
-    if (StringService.instance) {
-      return StringService.instance;
-    }
-
-    this.translationService = translationService;
-    this._language = 'en'; // default language
-    StringService.instance = this;
-  }
-
-  setLanguage(language) {
-    this._language = language;
-  }
-
-  get language() {
-    return this._language;
-  }
-
-  // Auth Messages
-  get dontHaveAccount() {
-    return this.translationService.getTranslation('dontHaveAccount');
-  }
-
-  get email() {
-    return this.translationService.getTranslation('email');
-  }
-
-  get forgotPassword() {
-    return this.translationService.getTranslation('forgotPassword');
-  }
-
-  get password() {
-    return this.translationService.getTranslation('password');
-  }
-
-  get signUp() {
-    return this.translationService.getTranslation('signUp');
-  }
-
-  get submit() {
-    return this.translationService.getTranslation('submit');
-  }
-
-  get title() {
-    return this.translationService.getTranslation('title');
-  }
-
-  get continue() {
-    return this.translationService.getTranslation('continue');
-  }
-
-  get enterEmail() {
-    return this.translationService.getTranslation('enterEmail');
-  }
-
-  get authLoginTitle() {
-    return this.translationService.getTranslation('authLoginTitle');
-  }
-
-  get authLoginEnterPassword() {
-    return this.translationService.getTranslation('authLoginEnterPassword');
-  }
-
-  get commonPassword() {
-    return this.translationService.getTranslation('commonPassword');
-  }
-
-  get commonBack() {
-    return this.translationService.getTranslation('commonBack');
-  }
-
-  get authForgotPasswordTitle() {
-    return this.translationService.getTranslation('authForgotPasswordTitle');
-  }
-
-  get authForgotPasswordResetPassword() {
-    return this.translationService.getTranslation('authForgotPasswordResetPassword');
-  }
-
-  get createPassword() {
-    return this.translationService.getTranslation('createPassword');
-  }
-
-  get createAPassword() {
-    return this.translationService.getTranslation('createAPassword');
-  }
-
-  get authRegisterAlreadyHaveAccount() {
-    return this.translationService.getTranslation('authRegisterAlreadyHaveAccount');
-  }
-
-  get commonAppName() {
-    return this.translationService.getTranslation('commonAppName');
-  }
-
-  get authLoginEnterEmail() {
-    return this.translationService.getTranslation('authLoginEnterEmail');
-  }
-
-  get authRegisterTitle() {
-    return this.translationService.getTranslation('authRegisterTitle');
-  }
-
-  get monitorGetAll() {
-    return this.translationService.getTranslation('monitorGetAll');
-  }
-
-  get monitorGetById() {
-    return this.translationService.getTranslation('monitorGetById');
-  }
-
-  get monitorCreate() {
-    return this.translationService.getTranslation('monitorCreate');
-  }
-
-  get monitorEdit() {
-    return this.translationService.getTranslation('monitorEdit');
-  }
-
-  get monitorDelete() {
-    return this.translationService.getTranslation('monitorDelete');
-  }
-
-  get monitorPause() {
-    return this.translationService.getTranslation('monitorPause');
-  }
-
-  get monitorResume() {
-    return this.translationService.getTranslation('monitorResume');
-  }
-
-  get monitorDemoAdded() {
-    return this.translationService.getTranslation('monitorDemoAdded');
-  }
-
-  get monitorStatsById() {
-    return this.translationService.getTranslation('monitorStatsById');
-  }
-
-  get monitorCertificate() {
-    return this.translationService.getTranslation('monitorCertificate');
-  }
-
-  // Maintenance Window Messages
-  get maintenanceWindowCreate() {
-    return this.translationService.getTranslation('maintenanceWindowCreate');
-  }
-
-  get maintenanceWindowGetById() {
-    return this.translationService.getTranslation('maintenanceWindowGetById');
-  }
-
-  get maintenanceWindowGetByTeam() {
-    return this.translationService.getTranslation('maintenanceWindowGetByTeam');
-  }
-
-  get maintenanceWindowDelete() {
-    return this.translationService.getTranslation('maintenanceWindowDelete');
-  }
-
-  get maintenanceWindowEdit() {
-    return this.translationService.getTranslation('maintenanceWindowEdit');
-  }
-
-  // Webhook Messages
-  get webhookUnsupportedPlatform() {
-    return this.translationService.getTranslation('webhookUnsupportedPlatform');
-  }
-
-  get webhookSendError() {
-      return this.translationService.getTranslation('webhookSendError');
-  }
-
-  get webhookSendSuccess() {
-      return this.translationService.getTranslation('webhookSendSuccess');
-  }
-
-  getWebhookUnsupportedPlatform(platform) {
-      return this.translationService.getTranslation('webhookUnsupportedPlatform')
-          .replace('{platform}', platform);
-  }
-
-  getWebhookSendError(platform) {
-      return this.translationService.getTranslation('webhookSendError')
-          .replace('{platform}', platform);
-  }
-
-  getMonitorStatus(name, status, url) {
-      return this.translationService.getTranslation('monitorStatus')
-          .replace('{name}', name)
-          .replace('{status}', status ? "up" : "down")
-          .replace('{url}', url);
-  }
-
-  // Error Messages
-  get unknownError() {
-    return this.translationService.getTranslation('unknownError');
-  }
-
-  get friendlyError() {
-    return this.translationService.getTranslation('friendlyError');
-  }
-
-  get authIncorrectPassword() {
-    return this.translationService.getTranslation('authIncorrectPassword');
-  }
-
-  get unauthorized() {
-    return this.translationService.getTranslation('unauthorized');
-  }
-
-  get authAdminExists() {
-    return this.translationService.getTranslation('authAdminExists');
-  }
-
-  get authInviteNotFound() {
-    return this.translationService.getTranslation('authInviteNotFound');
-  }
-
-  get unknownService() {
-    return this.translationService.getTranslation('unknownService');
-  }
-
-  get noAuthToken() {
-    return this.translationService.getTranslation('noAuthToken');
-  }
-
-  get invalidAuthToken() {
-    return this.translationService.getTranslation('invalidAuthToken');
-  }
-
-  get expiredAuthToken() {
-    return this.translationService.getTranslation('expiredAuthToken');
-  }
-
-  // Queue Messages
-  get queueGetMetrics() {
-    return this.translationService.getTranslation('queueGetMetrics');
-  }
-
-  get queueAddJob() {
-    return this.translationService.getTranslation('queueAddJob');
-  }
-
-  get queueObliterate() {
-    return this.translationService.getTranslation('queueObliterate');
-  }
-
-  // Job Queue Messages
-  get jobQueueDeleteJobSuccess() {
-    return this.translationService.getTranslation('jobQueueDeleteJobSuccess');
-  }
-
-  get jobQueuePauseJob() {
-    return this.translationService.getTranslation('jobQueuePauseJob');
-  }
-
-  get jobQueueResumeJob() {
-    return this.translationService.getTranslation('jobQueueResumeJob');
-  }
-
-  // Status Page Messages
-  get statusPageByUrl() {
-    return this.translationService.getTranslation('statusPageByUrl');
-  }
-
-  get statusPageCreate() {
-    return this.translationService.getTranslation('statusPageCreate');
-  }
-
-  get statusPageDelete() {
-    return this.translationService.getTranslation('statusPageDelete');
-  }
-
-  get statusPageUpdate() {
-    return this.translationService.getTranslation('statusPageUpdate');
-  }
-
-  get statusPageNotFound() {
-    return this.translationService.getTranslation('statusPageNotFound');
-  }
-
-  get statusPageByTeamId() {
-    return this.translationService.getTranslation('statusPageByTeamId');
-  }
-
-  get statusPageUrlNotUnique() {
-    return this.translationService.getTranslation('statusPageUrlNotUnique');
-  }
-
-  // Docker Messages
-  get dockerFail() {
-    return this.translationService.getTranslation('dockerFail');
-  }
-
-  get dockerNotFound() {
-    return this.translationService.getTranslation('dockerNotFound');
-  }
-
-  get dockerSuccess() {
-    return this.translationService.getTranslation('dockerSuccess');
-  }
-
-  // Port Messages
-  get portFail() {
-    return this.translationService.getTranslation('portFail');
-  }
-
-  get portSuccess() {
-    return this.translationService.getTranslation('portSuccess');
-  }
-
-  // Alert Messages
-  get alertCreate() {
-    return this.translationService.getTranslation('alertCreate');
-  }
-
-  get alertGetByUser() {
-    return this.translationService.getTranslation('alertGetByUser');
-  }
-
-  get alertGetByMonitor() {
-    return this.translationService.getTranslation('alertGetByMonitor');
-  }
-
-  get alertGetById() {
-    return this.translationService.getTranslation('alertGetById');
-  }
-
-  get alertEdit() {
-    return this.translationService.getTranslation('alertEdit');
-  }
-
-  get alertDelete() {
-    return this.translationService.getTranslation('alertDelete');
-  }
-
-  getDeletedCount(count) {
-    return this.translationService.getTranslation('deletedCount')
-      .replace('{count}', count);
-  }
-
-  get pingSuccess() {
-    return this.translationService.getTranslation('pingSuccess');
-  }
-
-  get getAppSettings() {
-    return this.translationService.getTranslation('getAppSettings');
-  }
-
-  get httpNetworkError() {
-    return this.translationService.getTranslation('httpNetworkError');
-  }
-
-  get httpNotJson() {
-    return this.translationService.getTranslation('httpNotJson');
-  }
-
-  get httpJsonPathError() {
-    return this.translationService.getTranslation('httpJsonPathError');
-  }
-
-  get httpEmptyResult() {
-    return this.translationService.getTranslation('httpEmptyResult');
-  }
-
-  get httpMatchSuccess() {
-    return this.translationService.getTranslation('httpMatchSuccess');
-  }
-
-  get httpMatchFail() {
-    return this.translationService.getTranslation('httpMatchFail');
-  }
-
-  get updateAppSettings() {
-    return this.translationService.getTranslation('updateAppSettings');
-  }
-
-  getDbFindMonitorById(monitorId) {
-    return this.translationService.getTranslation('dbFindMonitorById')
-      .replace('${monitorId}', monitorId);
-  }
+	static SERVICE_NAME = "StringService";
+
+	constructor(translationService) {
+		if (StringService.instance) {
+			return StringService.instance;
+		}
+
+		this.translationService = translationService;
+		this._language = "en"; // default language
+		StringService.instance = this;
+	}
+
+	setLanguage(language) {
+		this._language = language;
+	}
+
+	get language() {
+		return this._language;
+	}
+
+	// Auth Messages
+	get dontHaveAccount() {
+		return this.translationService.getTranslation("dontHaveAccount");
+	}
+
+	get email() {
+		return this.translationService.getTranslation("email");
+	}
+
+	get forgotPassword() {
+		return this.translationService.getTranslation("forgotPassword");
+	}
+
+	get password() {
+		return this.translationService.getTranslation("password");
+	}
+
+	get signUp() {
+		return this.translationService.getTranslation("signUp");
+	}
+
+	get submit() {
+		return this.translationService.getTranslation("submit");
+	}
+
+	get title() {
+		return this.translationService.getTranslation("title");
+	}
+
+	get continue() {
+		return this.translationService.getTranslation("continue");
+	}
+
+	get enterEmail() {
+		return this.translationService.getTranslation("enterEmail");
+	}
+
+	get authLoginTitle() {
+		return this.translationService.getTranslation("authLoginTitle");
+	}
+
+	get authLoginEnterPassword() {
+		return this.translationService.getTranslation("authLoginEnterPassword");
+	}
+
+	get commonPassword() {
+		return this.translationService.getTranslation("commonPassword");
+	}
+
+	get commonBack() {
+		return this.translationService.getTranslation("commonBack");
+	}
+
+	get authForgotPasswordTitle() {
+		return this.translationService.getTranslation("authForgotPasswordTitle");
+	}
+
+	get authForgotPasswordResetPassword() {
+		return this.translationService.getTranslation("authForgotPasswordResetPassword");
+	}
+
+	get createPassword() {
+		return this.translationService.getTranslation("createPassword");
+	}
+
+	get createAPassword() {
+		return this.translationService.getTranslation("createAPassword");
+	}
+
+	get authRegisterAlreadyHaveAccount() {
+		return this.translationService.getTranslation("authRegisterAlreadyHaveAccount");
+	}
+
+	get commonAppName() {
+		return this.translationService.getTranslation("commonAppName");
+	}
+
+	get authLoginEnterEmail() {
+		return this.translationService.getTranslation("authLoginEnterEmail");
+	}
+
+	get authRegisterTitle() {
+		return this.translationService.getTranslation("authRegisterTitle");
+	}
+
+	get monitorGetAll() {
+		return this.translationService.getTranslation("monitorGetAll");
+	}
+
+	get monitorGetById() {
+		return this.translationService.getTranslation("monitorGetById");
+	}
+
+	get monitorCreate() {
+		return this.translationService.getTranslation("monitorCreate");
+	}
+
+	get monitorEdit() {
+		return this.translationService.getTranslation("monitorEdit");
+	}
+
+	get monitorDelete() {
+		return this.translationService.getTranslation("monitorDelete");
+	}
+
+	get monitorPause() {
+		return this.translationService.getTranslation("monitorPause");
+	}
+
+	get monitorResume() {
+		return this.translationService.getTranslation("monitorResume");
+	}
+
+	get monitorDemoAdded() {
+		return this.translationService.getTranslation("monitorDemoAdded");
+	}
+
+	get monitorStatsById() {
+		return this.translationService.getTranslation("monitorStatsById");
+	}
+
+	get monitorCertificate() {
+		return this.translationService.getTranslation("monitorCertificate");
+	}
+
+	// Maintenance Window Messages
+	get maintenanceWindowCreate() {
+		return this.translationService.getTranslation("maintenanceWindowCreate");
+	}
+
+	get maintenanceWindowGetById() {
+		return this.translationService.getTranslation("maintenanceWindowGetById");
+	}
+
+	get maintenanceWindowGetByTeam() {
+		return this.translationService.getTranslation("maintenanceWindowGetByTeam");
+	}
+
+	get maintenanceWindowDelete() {
+		return this.translationService.getTranslation("maintenanceWindowDelete");
+	}
+
+	get maintenanceWindowEdit() {
+		return this.translationService.getTranslation("maintenanceWindowEdit");
+	}
+
+	// Webhook Messages
+	get webhookUnsupportedPlatform() {
+		return this.translationService.getTranslation("webhookUnsupportedPlatform");
+	}
+
+	get webhookSendError() {
+		return this.translationService.getTranslation("webhookSendError");
+	}
+
+	get webhookSendSuccess() {
+		return this.translationService.getTranslation("webhookSendSuccess");
+	}
+
+	getWebhookUnsupportedPlatform(platform) {
+		return this.translationService
+			.getTranslation("webhookUnsupportedPlatform")
+			.replace("{platform}", platform);
+	}
+
+	getWebhookSendError(platform) {
+		return this.translationService
+			.getTranslation("webhookSendError")
+			.replace("{platform}", platform);
+	}
+
+	getMonitorStatus(name, status, url) {
+		return this.translationService
+			.getTranslation("monitorStatus")
+			.replace("{name}", name)
+			.replace("{status}", status ? "up" : "down")
+			.replace("{url}", url);
+	}
+
+	// Error Messages
+	get unknownError() {
+		return this.translationService.getTranslation("unknownError");
+	}
+
+	get friendlyError() {
+		return this.translationService.getTranslation("friendlyError");
+	}
+
+	get authIncorrectPassword() {
+		return this.translationService.getTranslation("authIncorrectPassword");
+	}
+
+	get unauthorized() {
+		return this.translationService.getTranslation("unauthorized");
+	}
+
+	get authAdminExists() {
+		return this.translationService.getTranslation("authAdminExists");
+	}
+
+	get authInviteNotFound() {
+		return this.translationService.getTranslation("authInviteNotFound");
+	}
+
+	get unknownService() {
+		return this.translationService.getTranslation("unknownService");
+	}
+
+	get noAuthToken() {
+		return this.translationService.getTranslation("noAuthToken");
+	}
+
+	get invalidAuthToken() {
+		return this.translationService.getTranslation("invalidAuthToken");
+	}
+
+	get expiredAuthToken() {
+		return this.translationService.getTranslation("expiredAuthToken");
+	}
+
+	// Queue Messages
+	get queueGetMetrics() {
+		return this.translationService.getTranslation("queueGetMetrics");
+	}
+
+	get queueAddJob() {
+		return this.translationService.getTranslation("queueAddJob");
+	}
+
+	get queueObliterate() {
+		return this.translationService.getTranslation("queueObliterate");
+	}
+
+	// Job Queue Messages
+	get jobQueueDeleteJobSuccess() {
+		return this.translationService.getTranslation("jobQueueDeleteJobSuccess");
+	}
+
+	get jobQueuePauseJob() {
+		return this.translationService.getTranslation("jobQueuePauseJob");
+	}
+
+	get jobQueueResumeJob() {
+		return this.translationService.getTranslation("jobQueueResumeJob");
+	}
+
+	get jobQueueFlush() {
+		return this.translationService.getTranslation("queueFlush");
+	}
+
+	// Status Page Messages
+	get statusPageByUrl() {
+		return this.translationService.getTranslation("statusPageByUrl");
+	}
+
+	get statusPageCreate() {
+		return this.translationService.getTranslation("statusPageCreate");
+	}
+
+	get statusPageDelete() {
+		return this.translationService.getTranslation("statusPageDelete");
+	}
+
+	get statusPageUpdate() {
+		return this.translationService.getTranslation("statusPageUpdate");
+	}
+
+	get statusPageNotFound() {
+		return this.translationService.getTranslation("statusPageNotFound");
+	}
+
+	get statusPageByTeamId() {
+		return this.translationService.getTranslation("statusPageByTeamId");
+	}
+
+	get statusPageUrlNotUnique() {
+		return this.translationService.getTranslation("statusPageUrlNotUnique");
+	}
+
+	// Docker Messages
+	get dockerFail() {
+		return this.translationService.getTranslation("dockerFail");
+	}
+
+	get dockerNotFound() {
+		return this.translationService.getTranslation("dockerNotFound");
+	}
+
+	get dockerSuccess() {
+		return this.translationService.getTranslation("dockerSuccess");
+	}
+
+	// Port Messages
+	get portFail() {
+		return this.translationService.getTranslation("portFail");
+	}
+
+	get portSuccess() {
+		return this.translationService.getTranslation("portSuccess");
+	}
+
+	// Alert Messages
+	get alertCreate() {
+		return this.translationService.getTranslation("alertCreate");
+	}
+
+	get alertGetByUser() {
+		return this.translationService.getTranslation("alertGetByUser");
+	}
+
+	get alertGetByMonitor() {
+		return this.translationService.getTranslation("alertGetByMonitor");
+	}
+
+	get alertGetById() {
+		return this.translationService.getTranslation("alertGetById");
+	}
+
+	get alertEdit() {
+		return this.translationService.getTranslation("alertEdit");
+	}
+
+	get alertDelete() {
+		return this.translationService.getTranslation("alertDelete");
+	}
+
+	getDeletedCount(count) {
+		return this.translationService
+			.getTranslation("deletedCount")
+			.replace("{count}", count);
+	}
+
+	get pingSuccess() {
+		return this.translationService.getTranslation("pingSuccess");
+	}
+
+	get getAppSettings() {
+		return this.translationService.getTranslation("getAppSettings");
+	}
+
+	get httpNetworkError() {
+		return this.translationService.getTranslation("httpNetworkError");
+	}
+
+	get httpNotJson() {
+		return this.translationService.getTranslation("httpNotJson");
+	}
+
+	get httpJsonPathError() {
+		return this.translationService.getTranslation("httpJsonPathError");
+	}
+
+	get httpEmptyResult() {
+		return this.translationService.getTranslation("httpEmptyResult");
+	}
+
+	get httpMatchSuccess() {
+		return this.translationService.getTranslation("httpMatchSuccess");
+	}
+
+	get httpMatchFail() {
+		return this.translationService.getTranslation("httpMatchFail");
+	}
+
+	get updateAppSettings() {
+		return this.translationService.getTranslation("updateAppSettings");
+	}
+
+	getDbFindMonitorById(monitorId) {
+		return this.translationService
+			.getTranslation("dbFindMonitorById")
+			.replace("${monitorId}", monitorId);
+	}
 }
 
-export default StringService; 
+export default StringService;


### PR DESCRIPTION
This PR adds some methods and funcitonality to improve the reliability of the applicaiton.  Currently, if the server does not shut down cleanly Redis can become stuck due to DB locks.

This PR adds some methods to address this:

- [x] Add healthCheck method to assess whether or not Queues are stuck
- [x] Add a flushQueue method to flush keys from Redis
- [x] Adds a schedueld health check that uses those two methods to flush the queues if they become stuck
- [x] Add controller methods and routes to allow for manual use of those methods   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced secure endpoints for managing job queues, allowing authorized administrators to flush queues and check their health.
  - Enhanced job queue management with automated health monitoring and an improved shutdown process that now focuses on queue operations.
  - Strengthened access control, ensuring only privileged users can access critical queue functionalities.
  - Added new asynchronous methods for flushing the job queue and checking its health status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->