### PR TITLE
fix: update status page URL validation to disallow reserved chars

### DIFF
--- a/validation/joi.js
+++ b/validation/joi.js
@@ -443,7 +443,14 @@ const createStatusPageBodyValidation = joi.object({
 	teamId: joi.string().required(),
 	type: joi.string().valid("uptime", "distributed").required(),
 	companyName: joi.string().required(),
-	url: joi.string().required(),
+	url: joi
+		.string()
+		.pattern(/^[a-zA-Z0-9_-]+$/) // Only allow alphanumeric, underscore, and hyphen
+		.required()
+		.messages({
+			"string.pattern.base":
+				"URL can only contain letters, numbers, underscores, and hyphens",
+		}),
 	timezone: joi.string().optional(),
 	color: joi.string().optional(),
 	monitors: joi


### PR DESCRIPTION
This PR adds further validation to the create status page to disallow reserved characters that can break routing