### PR TITLE
Fix: All Monitors Incidents Check

### DIFF
--- a/db/mongo/modules/checkModule.js
+++ b/db/mongo/modules/checkModule.js
@@ -73,7 +73,7 @@ const createCheck = async (checkData) => {
 const getChecksByMonitor = async (req) => {
 	try {
 		const { monitorId } = req.params;
-		let { sortOrder, dateRange, filter, page, rowsPerPage, status } = req.query;
+		let { type, sortOrder, dateRange, filter, page, rowsPerPage, status } = req.query;
 		status = typeof status !== "undefined" ? false : undefined;
 		page = parseInt(page);
 		rowsPerPage = parseInt(rowsPerPage);
@@ -116,9 +116,6 @@ const getChecksByMonitor = async (req) => {
 			skip = page * rowsPerPage;
 		}
 
-		const monitor= await Monitor.findOne({ _id: matchStage.monitorId });
-		const monitorType = monitor?.type;
-
 		const checkModels = {
 			http: Check,
 			ping: Check,
@@ -127,9 +124,10 @@ const getChecksByMonitor = async (req) => {
 			pagespeed: PageSpeedCheck,
 			hardware: HardwareCheck,
 			distributed_http: DistributedUptimeCheck,
+			distributed_test: DistributedUptimeCheck
 		}
 
-		const Model = checkModels[monitorType];
+		const Model = checkModels[type];
 
 		const checks = await Model.aggregate([
 			{ $match: matchStage },

--- a/db/mongo/modules/checkModule.js
+++ b/db/mongo/modules/checkModule.js
@@ -201,51 +201,43 @@ const getChecksByTeam = async (req) => {
 			skip = page * rowsPerPage;
 		}
 
-		const aggregateChecks = async (Model) => {
-			return Model.aggregate([
-				{ $match: matchStage },
-				{ $sort: { createdAt: sortOrder } },
-				{
-					$facet: {
-						summary: [{ $count: "checksCount" }],
-						checks: [{ $skip: skip }, { $limit: rowsPerPage }],
-					},
+		const aggregatePipeline = [
+			{ $match: matchStage },
+			{ $unionWith: {
+				coll: 'hardwarechecks',
+				pipeline: [
+					{ $match: matchStage }
+				]
+			}},
+			{ $unionWith: {
+				coll: 'pagespeedchecks',
+				pipeline: [
+					{ $match: matchStage }
+				]
+			}},
+			{ $unionWith: {
+				coll: 'distributeduptimechecks',
+				pipeline: [
+					{ $match: matchStage }
+				]
+			}},
+			{ $sort: { createdAt: sortOrder } },
+			{
+				$facet: {
+					summary: [{ $count: "checksCount" }],
+					checks: [{ $skip: skip }, { $limit: rowsPerPage }],
 				},
-				{
-					$project: {
-						checksCount: { $arrayElemAt: ["$summary.checksCount", 0] },
-						checks: "$checks",
-					},
+			},
+			{
+				$project: {
+					checksCount: { $arrayElemAt: ["$summary.checksCount", 0] },
+					checks: "$checks",
 				},
-			]);
-		};
+			}
+		];
 
-		const [uptimeChecks, hardwareChecks, pagespeedChecks, distributedChecks] = await Promise.all([
-			aggregateChecks(Check),
-			aggregateChecks(HardwareCheck),
-			aggregateChecks(PageSpeedCheck),
-			aggregateChecks(DistributedUptimeCheck),
-		]);
-
-		const totalChecks =
-			(uptimeChecks[0]?.checksCount || 0) +
-			(hardwareChecks[0]?.checksCount || 0) +
-			(pagespeedChecks[0]?.checksCount || 0) +
-			(distributedChecks[0]?.checksCount || 0);
-
-		const combinedChecks = [
-			...(uptimeChecks[0]?.checks || []),
-			...(hardwareChecks[0]?.checks || []),
-			...(pagespeedChecks[0]?.checks || []),
-			...(distributedChecks[0]?.checks || []),
-		].sort((a, b) =>
-			sortOrder === 1 ? a.createdAt - b.createdAt : b.createdAt - a.createdAt
-		);
-
-		return {
-			checksCount: totalChecks,
-			checks: combinedChecks,
-		};
+		const checks = await Check.aggregate(aggregatePipeline);
+		return checks[0];
 	} catch (error) {
 		error.service = SERVICE_NAME;
 		error.method = "getChecksByTeam";

--- a/db/mongo/modules/checkModule.js
+++ b/db/mongo/modules/checkModule.js
@@ -1,5 +1,8 @@
 import Check from "../../models/Check.js";
 import Monitor from "../../models/Monitor.js";
+import HardwareCheck from "../../models/HardwareCheck.js";
+import PageSpeedCheck from "../../models/PageSpeedCheck.js";
+import DistributedUptimeCheck from "../../models/DistributedUptimeCheck.js";
 import User from "../../models/User.js";
 import logger from "../../../utils/logger.js";
 import { ObjectId } from "mongodb";
@@ -112,7 +115,23 @@ const getChecksByMonitor = async (req) => {
 		if (page && rowsPerPage) {
 			skip = page * rowsPerPage;
 		}
-		const checks = await Check.aggregate([
+
+		const monitor= await Monitor.findOne({ _id: matchStage.monitorId });
+		const monitorType = monitor?.type;
+
+		const checkModels = {
+			http: Check,
+			ping: Check,
+			docker: Check,
+			port: Check,
+			pagespeed: PageSpeedCheck,
+			hardware: HardwareCheck,
+			distributed_http: DistributedUptimeCheck,
+		}
+
+		const Model = checkModels[monitorType];
+
+		const checks = await Model.aggregate([
 			{ $match: matchStage },
 			{ $sort: { createdAt: sortOrder } },
 			{
@@ -184,25 +203,51 @@ const getChecksByTeam = async (req) => {
 			skip = page * rowsPerPage;
 		}
 
-		const checks = await Check.aggregate([
-			{ $match: matchStage },
-			{ $sort: { createdAt: sortOrder } },
+		const aggregateChecks = async (Model) => {
+			return Model.aggregate([
+				{ $match: matchStage },
+				{ $sort: { createdAt: sortOrder } },
+				{
+					$facet: {
+						summary: [{ $count: "checksCount" }],
+						checks: [{ $skip: skip }, { $limit: rowsPerPage }],
+					},
+				},
+				{
+					$project: {
+						checksCount: { $arrayElemAt: ["$summary.checksCount", 0] },
+						checks: "$checks",
+					},
+				},
+			]);
+		};
 
-			{
-				$facet: {
-					summary: [{ $count: "checksCount" }],
-					checks: [{ $skip: skip }, { $limit: rowsPerPage }],
-				},
-			},
-			{
-				$project: {
-					checksCount: { $arrayElemAt: ["$summary.checksCount", 0] },
-					checks: "$checks",
-				},
-			},
+		const [uptimeChecks, hardwareChecks, pagespeedChecks, distributedChecks] = await Promise.all([
+			aggregateChecks(Check),
+			aggregateChecks(HardwareCheck),
+			aggregateChecks(PageSpeedCheck),
+			aggregateChecks(DistributedUptimeCheck),
 		]);
 
-		return checks[0];
+		const totalChecks =
+			(uptimeChecks[0]?.checksCount || 0) +
+			(hardwareChecks[0]?.checksCount || 0) +
+			(pagespeedChecks[0]?.checksCount || 0) +
+			(distributedChecks[0]?.checksCount || 0);
+
+		const combinedChecks = [
+			...(uptimeChecks[0]?.checks || []),
+			...(hardwareChecks[0]?.checks || []),
+			...(pagespeedChecks[0]?.checks || []),
+			...(distributedChecks[0]?.checks || []),
+		].sort((a, b) =>
+			sortOrder === 1 ? a.createdAt - b.createdAt : b.createdAt - a.createdAt
+		);
+
+		return {
+			checksCount: totalChecks,
+			checks: combinedChecks,
+		};
 	} catch (error) {
 		error.service = SERVICE_NAME;
 		error.method = "getChecksByTeam";

--- a/validation/joi.js
+++ b/validation/joi.js
@@ -299,6 +299,7 @@ const getChecksParamValidation = joi.object({
 });
 
 const getChecksQueryValidation = joi.object({
+	type: joi.string().valid("http", "ping", "pagespeed", "hardware", "docker", "port", "distributed_http", "distributed_test"),
 	sortOrder: joi.string().valid("asc", "desc"),
 	limit: joi.number(),
 	dateRange: joi.string().valid("hour", "day", "week", "month", "all"),


### PR DESCRIPTION
### Describe your changes

`getChecksByTeam`

- Utilizes the same aggregation pipeline method as previously implemented, now enhanced with the addition of unionWith. This feature enables querying multiple collections with the same ID using a single database query.

`getChecksByMonitor`

- Updated the function to dynamically select the correct check model based on the monitor type.
- Retrieved the monitor type using Monitor.findOne({ _id: matchStage.monitorId }). [This can be passed on from FE]
- Used a mapping object (checkModels) to assign the appropriate model (Check, HardwareCheck, PageSpeedCheck, etc.).

### Fixes

https://github.com/bluewave-labs/Checkmate/issues/1844

<img width="1138" alt="Screenshot 2025-03-04 at 11 37 21 AM" src="https://github.com/user-attachments/assets/300f8d75-7151-4bd7-91fa-c1cbdb219e47" />
<img width="1159" alt="Screenshot 2025-03-04 at 11 37 29 AM" src="https://github.com/user-attachments/assets/b9c741e7-4c65-4b1e-89d0-363c4e4c1724" />
<img width="1129" alt="Screenshot 2025-03-04 at 11 37 37 AM" src="https://github.com/user-attachments/assets/589dda28-73cd-45ec-bf40-26b81ef8cee2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded monitoring capabilities to include a broader range of check types, resulting in a more comprehensive overview.
	- Introduced a new validation property for check queries, allowing for more specific types of checks.

- **Refactor**
	- Optimized the process for aggregating check data by handling operations concurrently, which enhances the speed and reliability of the monitoring results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->