### PR TITLE
feat: running stats

### DIFF
--- a/controllers/diagnosticController.js
+++ b/controllers/diagnosticController.js
@@ -1,0 +1,23 @@
+import { handleError } from "./controllerUtils.js";
+const SERVICE_NAME = "diagnosticController";
+
+class DiagnosticController {
+	constructor(db) {
+		this.db = db;
+		this.getDistributedUptimeDbExecutionStats =
+			this.getDistributedUptimeDbExecutionStats.bind(this);
+	}
+
+	async getDistributedUptimeDbExecutionStats(req, res, next) {
+		try {
+			const data = await this.db.getDistributedUptimeDbExecutionStats(req);
+			return res.success({
+				msg: "OK",
+				data,
+			});
+		} catch (error) {
+			next(handleError(error, SERVICE_NAME, "getDbExecutionStats"));
+		}
+	}
+}
+export default DiagnosticController;

--- a/controllers/distributedUptimeController.js
+++ b/controllers/distributedUptimeController.js
@@ -32,6 +32,7 @@ class DistributedUptimeController {
 				tls_took,
 				status_code,
 				error,
+				upt_burnt,
 			} = result;
 
 			// Calculate response time
@@ -57,6 +58,7 @@ class DistributedUptimeController {
 				conn_took,
 				connect_took,
 				tls_took,
+				upt_burnt,
 			};
 			if (error) {
 				const code = status_code || this.NETWORK_ERROR;

--- a/db/models/MonitorStats.js
+++ b/db/models/MonitorStats.js
@@ -1,0 +1,50 @@
+import mongoose from "mongoose";
+
+const MonitorSatsSchema = new mongoose.Schema(
+	{
+		monitorId: {
+			type: mongoose.Schema.Types.ObjectId,
+			ref: "Monitor",
+			immutable: true,
+			index: true,
+		},
+		avgResponseTime: {
+			type: Number,
+			default: 0,
+		},
+		totalChecks: {
+			type: Number,
+			default: 0,
+		},
+		totalUpChecks: {
+			type: Number,
+			default: 0,
+		},
+		totalDownChecks: {
+			type: Number,
+			default: 0,
+		},
+		uptimePercentage: {
+			type: Number,
+			default: 0,
+		},
+		lastCheck: {
+			type: mongoose.Schema.Types.ObjectId,
+			ref: "Check",
+			default: null,
+		},
+		timeSinceLastCheck: {
+			type: Number,
+			default: 0,
+		},
+		uptBurnt: {
+			type: mongoose.Schema.Types.Decimal128,
+			required: false,
+		},
+	},
+	{ timestamps: true }
+);
+
+const MonitorSats = mongoose.model("MonitorSats", MonitorSatsSchema);
+
+export default MonitorSats;

--- a/db/models/MonitorStats.js
+++ b/db/models/MonitorStats.js
@@ -28,12 +28,7 @@ const MonitorSatsSchema = new mongoose.Schema(
 			type: Number,
 			default: 0,
 		},
-		lastCheck: {
-			type: mongoose.Schema.Types.ObjectId,
-			ref: "Check",
-			default: null,
-		},
-		timeSinceLastCheck: {
+		lastCheckTimestamp: {
 			type: Number,
 			default: 0,
 		},

--- a/db/mongo/MongoDB.js
+++ b/db/mongo/MongoDB.js
@@ -68,6 +68,11 @@ import * as settingsModule from "./modules/settingsModule.js";
 //****************************************
 import * as statusPageModule from "./modules/statusPageModule.js";
 
+//****************************************
+// Diagnostic
+//****************************************
+import * as diagnosticModule from "./modules/diagnosticModule.js";
+
 class MongoDB {
 	static SERVICE_NAME = "MongoDB";
 
@@ -84,6 +89,7 @@ class MongoDB {
 		Object.assign(this, notificationModule);
 		Object.assign(this, settingsModule);
 		Object.assign(this, statusPageModule);
+		Object.assign(this, diagnosticModule);
 	}
 
 	connect = async () => {

--- a/db/mongo/modules/diagnosticModule.js
+++ b/db/mongo/modules/diagnosticModule.js
@@ -1,0 +1,57 @@
+import DistributedUptimeCheck from "../../models/DistributedUptimeCheck.js";
+import Monitor from "../../models/Monitor.js";
+const SERVICE_NAME = "diagnosticModule";
+import {
+	buildDePINDetailsByDateRange,
+	buildDePINLatestChecks,
+} from "./monitorModuleQueries.js";
+import { getDateRange } from "./monitorModule.js";
+
+const getDistributedUptimeDbExecutionStats = async (req) => {
+	try {
+		const { monitorId } = req?.params ?? {};
+		if (typeof monitorId === "undefined") {
+			throw new Error();
+		}
+		const monitor = await Monitor.findById(monitorId);
+		if (monitor === null || monitor === undefined) {
+			throw new Error(this.stringService.dbFindMonitorById(monitorId));
+		}
+
+		const { dateRange } = req.query;
+		const dates = getDateRange(dateRange);
+		const formatLookup = {
+			recent: "%Y-%m-%dT%H:%M:00Z",
+			day: {
+				$concat: [
+					{ $dateToString: { format: "%Y-%m-%dT%H:", date: "$createdAt" } },
+					{
+						$cond: [{ $lt: [{ $minute: "$createdAt" }, 30] }, "00:00Z", "30:00Z"],
+					},
+				],
+			},
+			week: "%Y-%m-%dT%H:00:00Z",
+			month: "%Y-%m-%dT00:00:00Z",
+		};
+
+		const dateString = formatLookup[dateRange];
+
+		const dePINDetailsByDateRangeStats = await DistributedUptimeCheck.aggregate(
+			buildDePINDetailsByDateRange(monitor, dates, dateString)
+		).explain("executionStats");
+		const latestChecksStats = await DistributedUptimeCheck.aggregate(
+			buildDePINLatestChecks(monitor)
+		).explain("executionStats");
+
+		return {
+			dePINDetailsByDateRangeStats,
+			latestChecksStats,
+		};
+	} catch (error) {
+		error.service = SERVICE_NAME;
+		error.method = "getAllMonitorsWithUptimeStats";
+		throw error;
+	}
+};
+
+export { getDistributedUptimeDbExecutionStats };

--- a/db/mongo/modules/monitorModule.js
+++ b/db/mongo/modules/monitorModule.js
@@ -15,6 +15,7 @@ import {
 	buildUptimeDetailsPipeline,
 	buildHardwareDetailsPipeline,
 	buildDePINDetailsByDateRange,
+	buildDePINLatestChecks,
 } from "./monitorModuleQueries.js";
 import { ObjectId } from "mongodb";
 const __filename = fileURLToPath(import.meta.url);
@@ -402,9 +403,12 @@ const getDistributedUptimeDetailsById = async (req) => {
 
 		const dateString = formatLookup[dateRange];
 
-		const monitorStats = await MonitorStats.findOne({ monitorId });
+		const monitorStats = await MonitorStats.findOne({ monitorId }).lean();
 		const dePINDetailsByDateRange = await DistributedUptimeCheck.aggregate(
 			buildDePINDetailsByDateRange(monitor, dates, dateString)
+		);
+		const latestChecks = await DistributedUptimeCheck.aggregate(
+			buildDePINLatestChecks(monitor)
 		);
 
 		const checkData = dePINDetailsByDateRange[0];
@@ -416,6 +420,7 @@ const getDistributedUptimeDetailsById = async (req) => {
 
 		const data = {
 			...monitor.toObject(),
+			latestChecks,
 			avgResponseTime: monitorStats?.avgResponseTime,
 			totalChecks: monitorStats?.totalChecks,
 			totalUpChecks: monitorStats?.totalUpChecks,

--- a/db/mongo/modules/monitorModule.js
+++ b/db/mongo/modules/monitorModule.js
@@ -1,4 +1,5 @@
 import Monitor from "../../models/Monitor.js";
+import MonitorStats from "../../models/MonitorStats.js";
 import Check from "../../models/Check.js";
 import PageSpeedCheck from "../../models/PageSpeedCheck.js";
 import HardwareCheck from "../../models/HardwareCheck.js";
@@ -13,8 +14,6 @@ import { fileURLToPath } from "url";
 import {
 	buildUptimeDetailsPipeline,
 	buildHardwareDetailsPipeline,
-	buildDistributedUptimeDetailsPipeline,
-	buildDePINDetails,
 	buildDePINDetailsByDateRange,
 } from "./monitorModuleQueries.js";
 import { ObjectId } from "mongodb";
@@ -403,15 +402,11 @@ const getDistributedUptimeDetailsById = async (req) => {
 
 		const dateString = formatLookup[dateRange];
 
-		const dePINDetails = await DistributedUptimeCheck.aggregate(
-			buildDePINDetails(monitor, dates)
-		);
-
+		const monitorStats = await MonitorStats.findOne({ monitorId });
 		const dePINDetailsByDateRange = await DistributedUptimeCheck.aggregate(
 			buildDePINDetailsByDateRange(monitor, dates, dateString)
 		);
 
-		const monitorData = dePINDetails[0];
 		const checkData = dePINDetailsByDateRange[0];
 		const normalizedGroupChecks = NormalizeDataUptimeDetails(
 			checkData.groupedChecks,
@@ -419,14 +414,20 @@ const getDistributedUptimeDetailsById = async (req) => {
 			100
 		);
 
-		const monitorStats = {
+		const data = {
 			...monitor.toObject(),
-			...monitorData,
+			avgResponseTime: monitorStats?.avgResponseTime,
+			totalChecks: monitorStats?.totalChecks,
+			totalUpChecks: monitorStats?.totalUpChecks,
+			totalDownChecks: monitorStats?.totalDownChecks,
+			uptimePercentage: monitorStats?.uptimePercentage,
+			lastCheckTimestamp: monitorStats?.lastCheckTimestamp,
+			uptBurnt: monitorStats?.uptBurnt,
 			groupedChecks: normalizedGroupChecks,
 			groupedMapChecks: checkData.groupedMapChecks,
 		};
 
-		return monitorStats;
+		return data;
 	} catch (error) {
 		error.service = SERVICE_NAME;
 		error.method = "getDistributedUptimeDetailsById";

--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -534,76 +534,6 @@ const buildHardwareDetailsPipeline = (monitor, dates, dateString) => {
 	];
 };
 
-const buildDePINDetails = (monitor, dates) => {
-	return [
-		{
-			$match: {
-				monitorId: monitor._id,
-				createdAt: { $gte: dates.start, $lte: dates.end }, // Temporary until Stats object implemented
-			},
-		},
-		{
-			$sort: {
-				createdAt: 1,
-			},
-		},
-		{
-			$group: {
-				_id: null,
-				avgResponseTime: {
-					$avg: "$responseTime",
-				},
-				lastCheck: {
-					$last: "$$ROOT",
-				},
-				totalChecks: {
-					$sum: 1,
-				},
-				downChecks: {
-					$sum: {
-						$cond: [{ $eq: ["$status", false] }, 1, 0],
-					},
-				},
-				upChecks: {
-					$sum: {
-						$cond: [{ $eq: ["$status", true] }, 1, 0],
-					},
-				},
-				uptBurnt: {
-					$sum: "$uptBurnt",
-				},
-			},
-		},
-		{
-			$project: {
-				avgResponseTime: 1,
-				totalChecks: 1,
-				downChecks: 1,
-				upChecks: 1,
-				uptBurnt: { $toString: "$uptBurnt" },
-				timeSinceLastCheck: {
-					$let: {
-						vars: {
-							lastCheck: "$lastCheck",
-						},
-						in: {
-							$cond: [
-								{
-									$ifNull: ["$$lastCheck", false],
-								},
-								{
-									$subtract: [new Date(), "$$lastCheck.createdAt"],
-								},
-								0,
-							],
-						},
-					},
-				},
-			},
-		},
-	];
-};
-
 const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
 	return [
 		{
@@ -884,6 +814,5 @@ export {
 	buildUptimeDetailsPipeline,
 	buildHardwareDetailsPipeline,
 	buildDistributedUptimeDetailsPipeline,
-	buildDePINDetails,
 	buildDePINDetailsByDateRange,
 };

--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -534,80 +534,6 @@ const buildHardwareDetailsPipeline = (monitor, dates, dateString) => {
 	];
 };
 
-const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
-	return [
-		{
-			$match: {
-				monitorId: monitor._id,
-				createdAt: { $gte: dates.start, $lte: dates.end },
-			},
-		},
-		{
-			$facet: {
-				groupedMapChecks: [
-					{
-						$group: {
-							_id: {
-								date: {
-									$dateToString: {
-										format: dateString,
-										date: "$createdAt",
-									},
-								},
-								city: "$city",
-								lat: "$location.lat",
-								lng: "$location.lng",
-							},
-							city: { $first: "$city" },
-							lat: { $first: "$location.lat" },
-							lng: { $first: "$location.lng" },
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-							totalChecks: {
-								$sum: 1,
-							},
-						},
-					},
-					{
-						$sort: {
-							"_id.date": 1,
-						},
-					},
-				],
-				groupedChecks: [
-					{
-						$group: {
-							_id: {
-								date: {
-									$dateToString: {
-										format: dateString,
-										date: "$createdAt",
-									},
-								},
-							},
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-						},
-					},
-					{
-						$sort: {
-							"_id.date": 1,
-						},
-					},
-				],
-			},
-		},
-		{
-			$project: {
-				groupedMapChecks: "$groupedMapChecks",
-				groupedChecks: "$groupedChecks",
-			},
-		},
-	];
-};
-
 const buildDistributedUptimeDetailsPipeline = (monitor, dates, dateString) => {
 	return [
 		{
@@ -810,9 +736,112 @@ const buildDistributedUptimeDetailsPipeline = (monitor, dates, dateString) => {
 	];
 };
 
+const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
+	return [
+		{
+			$match: {
+				monitorId: monitor._id,
+				createdAt: { $gte: dates.start, $lte: dates.end },
+			},
+		},
+		{
+			$facet: {
+				groupedMapChecks: [
+					{
+						$group: {
+							_id: {
+								date: {
+									$dateToString: {
+										format: dateString,
+										date: "$createdAt",
+									},
+								},
+								city: "$city",
+								lat: "$location.lat",
+								lng: "$location.lng",
+							},
+							city: { $first: "$city" },
+							lat: { $first: "$location.lat" },
+							lng: { $first: "$location.lng" },
+							avgResponseTime: {
+								$avg: "$responseTime",
+							},
+							totalChecks: {
+								$sum: 1,
+							},
+						},
+					},
+					{
+						$sort: {
+							"_id.date": 1,
+						},
+					},
+				],
+				groupedChecks: [
+					{
+						$group: {
+							_id: {
+								date: {
+									$dateToString: {
+										format: dateString,
+										date: "$createdAt",
+									},
+								},
+							},
+							avgResponseTime: {
+								$avg: "$responseTime",
+							},
+						},
+					},
+					{
+						$sort: {
+							"_id.date": 1,
+						},
+					},
+				],
+			},
+		},
+		{
+			$project: {
+				groupedMapChecks: "$groupedMapChecks",
+				groupedChecks: "$groupedChecks",
+			},
+		},
+	];
+};
+
+const buildDePINLatestChecks = (monitor) => {
+	return [
+		{
+			$match: {
+				monitorId: monitor._id,
+			},
+		},
+		{
+			$sort: { createdAt: -1 },
+		},
+		{
+			$limit: 5,
+		},
+		{
+			$project: {
+				responseTime: 1,
+				city: 1,
+				countryCode: 1,
+				uptBurnt: {
+					$toString: {
+						$ifNull: ["$uptBurnt", 0],
+					},
+				},
+			},
+		},
+	];
+};
+
 export {
 	buildUptimeDetailsPipeline,
 	buildHardwareDetailsPipeline,
 	buildDistributedUptimeDetailsPipeline,
 	buildDePINDetailsByDateRange,
+	buildDePINLatestChecks,
 };

--- a/index.js
+++ b/index.js
@@ -39,8 +39,10 @@ import DistributedUptimeRoutes from "./routes/distributedUptimeRoute.js";
 import DistributedUptimeController from "./controllers/distributedUptimeController.js";
 
 import NotificationRoutes from "./routes/notificationRoute.js";
-
 import NotificationController from "./controllers/notificationController.js";
+
+import DiagnosticRoutes from "./routes/diagnosticRoute.js";
+import DiagnosticController from "./controllers/diagnosticController.js";
 
 //JobQueue service and dependencies
 import JobQueue from "./service/jobQueue.js";
@@ -272,6 +274,10 @@ const startApp = async () => {
 		ServiceRegistry.get(StatusService.SERVICE_NAME)
 	);
 
+	const diagnosticController = new DiagnosticController(
+		ServiceRegistry.get(MongoDB.SERVICE_NAME)
+	);
+
 	//Create routes
 	const authRoutes = new AuthRoutes(authController);
 	const monitorRoutes = new MonitorRoutes(monitorController);
@@ -286,9 +292,8 @@ const startApp = async () => {
 	const distributedUptimeRoutes = new DistributedUptimeRoutes(
 		distributedUptimeController
 	);
-
 	const notificationRoutes = new NotificationRoutes(notificationController);
-
+	const diagnosticRoutes = new DiagnosticRoutes(diagnosticController);
 	// Init job queue
 	await jobQueue.initJobQueue();
 	// Middleware
@@ -312,6 +317,7 @@ const startApp = async () => {
 	app.use("/api/v1/distributed-uptime", distributedUptimeRoutes.getRouter());
 	app.use("/api/v1/status-page", statusPageRoutes.getRouter());
 	app.use("/api/v1/notifications", verifyJWT, notificationRoutes.getRouter());
+	app.use("/api/v1/diagnostic", verifyJWT, diagnosticRoutes.getRouter());
 	app.use("/api/v1/health", (req, res) => {
 		res.json({
 			status: "OK",

--- a/routes/diagnosticRoute.js
+++ b/routes/diagnosticRoute.js
@@ -1,0 +1,21 @@
+import { Router } from "express";
+
+class DiagnosticRoutes {
+	constructor(diagnosticController) {
+		this.router = Router();
+		this.diagnosticController = diagnosticController;
+		this.initRoutes();
+	}
+	initRoutes() {
+		this.router.get(
+			"/db/execution-stats/:monitorId",
+			this.diagnosticController.getDistributedUptimeDbExecutionStats
+		);
+	}
+
+	getRouter() {
+		return this.router;
+	}
+}
+
+export default DiagnosticRoutes;

--- a/service/statusService.js
+++ b/service/statusService.js
@@ -40,7 +40,7 @@ class StatusService {
 
 			// Avg response time:
 			let avgResponseTime = stats.avgResponseTime;
-			if (typeof responseTime === "undefined" || responseTime === null) {
+			if (typeof responseTime !== "undefined" && responseTime !== null) {
 				if (avgResponseTime === 0) {
 					avgResponseTime = responseTime;
 				} else {
@@ -49,6 +49,7 @@ class StatusService {
 						stats.totalChecks;
 				}
 			}
+			stats.avgResponseTime = avgResponseTime;
 
 			// Total checks
 			stats.totalChecks++;

--- a/service/statusService.js
+++ b/service/statusService.js
@@ -1,3 +1,5 @@
+import MonitorStats from "../db/models/MonitorStats.js";
+import { safelyParseFloat } from "../utils/dataUtils.js";
 const SERVICE_NAME = "StatusService";
 
 class StatusService {
@@ -12,6 +14,79 @@ class StatusService {
 		this.db = db;
 		this.logger = logger;
 		this.SERVICE_NAME = SERVICE_NAME;
+	}
+
+	async updateRunningStats({ monitor, networkResponse }) {
+		try {
+			const monitorId = monitor._id;
+			const { responseTime, status, upt_burnt } = networkResponse;
+			// Get stats
+			let stats = await MonitorStats.findOne({ monitorId });
+			if (!stats) {
+				stats = new MonitorStats({
+					monitorId,
+					avgResponseTime: 0,
+					totalChecks: 0,
+					totalUpChecks: 0,
+					totalDownChecks: 0,
+					uptimePercentage: 0,
+					lastCheck: null,
+					timeSInceLastCheck: 0,
+					uptBurnt: 0,
+				});
+			}
+
+			// Update stats
+
+			// Avg response time:
+			let avgResponseTime = stats.avgResponseTime;
+			if (typeof responseTime === "undefined" || responseTime === null) {
+				if (avgResponseTime === 0) {
+					avgResponseTime = responseTime;
+				} else {
+					avgResponseTime =
+						(avgResponseTime * (stats.totalChecks - 1) + responseTime) /
+						stats.totalChecks;
+				}
+			}
+
+			// Total checks
+			stats.totalChecks++;
+			if (status === true) {
+				stats.totalUpChecks++;
+			} else {
+				stats.totalDownChecks++;
+			}
+
+			// Calculate uptime percentage
+			let uptimePercentage;
+			if (stats.totalChecks > 0) {
+				uptimePercentage = stats.totalUpChecks / stats.totalChecks;
+			} else {
+				uptimePercentage = status === true ? 100 : 0;
+			}
+			stats.uptimePercentage = uptimePercentage;
+
+			// latest check
+			stats.lastCheckTimestamp = new Date().getTime();
+
+			// UPT burned
+			if (typeof upt_burnt !== "undefined" && upt_burnt !== null) {
+				const currentUptBurnt = safelyParseFloat(stats.uptBurnt);
+				const newUptBurnt = safelyParseFloat(upt_burnt);
+				stats.uptBurnt = currentUptBurnt + newUptBurnt;
+			}
+			await stats.save();
+			return true;
+		} catch (error) {
+			this.logger.error({
+				service: this.SERVICE_NAME,
+				message: error.message,
+				method: "updateRunningStats",
+				stack: error.stack,
+			});
+			return false;
+		}
 	}
 
 	getStatusString = (status) => {
@@ -36,6 +111,10 @@ class StatusService {
 		try {
 			const { monitorId, status } = networkResponse;
 			const monitor = await this.db.getMonitorById(monitorId);
+
+			// Update running stats
+			this.updateRunningStats({ monitor, networkResponse });
+
 			// No change in monitor status, return early
 			if (monitor.status === status)
 				return { monitor, statusChanged: false, prevStatus: monitor.status };

--- a/utils/dataUtils.js
+++ b/utils/dataUtils.js
@@ -84,7 +84,31 @@ const NormalizeDataUptimeDetails = (checks, rangeMin, rangeMax) => {
 	}
 };
 
+const safelyParseFloat = (value, defaultValue = 0) => {
+	if (value === null || typeof value === "undefined") {
+		return defaultValue;
+	}
+	const stringValue = String(value).trim();
+
+	if (typeof value === "number" && !isNaN(value)) {
+		return value;
+	}
+
+	if (stringValue === "") {
+		return defaultValue;
+	}
+
+	const parsedValue = parseFloat(stringValue);
+
+	if (isNaN(parsedValue) || !isFinite(parsedValue)) {
+		return defaultValue;
+	}
+
+	return parsedValue;
+};
+
 export {
+	safelyParseFloat,
 	calculatePercentile,
 	NormalizeData,
 	calculatePercentileUptimeDetails,


### PR DESCRIPTION
This PR implements a running stats collection object to update long running stats like avg response time.  This elimatest the need for large queries

- [x] Add a monitor stats model
- [x] Calculate monitor stats on check return