### PR TITLE
feat: avg by city

### DIFF
--- a/db/models/DistributedUptimeCheck.js
+++ b/db/models/DistributedUptimeCheck.js
@@ -105,6 +105,10 @@ const DistributedUptimeCheckSchema = mongoose.Schema(
 			type: mongoose.Schema.Types.Decimal128,
 			required: false,
 		},
+		count: {
+			type: Number,
+			required: false,
+		},
 	},
 	{ timestamps: true }
 );

--- a/db/models/DistributedUptimeCheck.js
+++ b/db/models/DistributedUptimeCheck.js
@@ -121,8 +121,8 @@ DistributedUptimeCheckSchema.pre("save", function (next) {
 });
 
 DistributedUptimeCheckSchema.index({ createdAt: 1 });
-DistributedUptimeCheckSchema.index({ monitorId: 1, createdAt: 1 });
-DistributedUptimeCheckSchema.index({ monitorId: 1, createdAt: -1 });
+DistributedUptimeCheckSchema.index({ monitorId: 1, updatedAt: 1 });
+DistributedUptimeCheckSchema.index({ monitorId: 1, updatedAt: -1 });
 DistributedUptimeCheckSchema.index(
 	{
 		monitorId: 1,

--- a/db/mongo/modules/distributedCheckModule.js
+++ b/db/mongo/modules/distributedCheckModule.js
@@ -1,9 +1,55 @@
 import DistributedUptimeCheck from "../../models/DistributedUptimeCheck.js";
+import { ObjectId } from "mongodb";
+
 const SERVICE_NAME = "distributedCheckModule";
 
 const createDistributedCheck = async (checkData) => {
 	try {
-		const check = await new DistributedUptimeCheck({ ...checkData }).save();
+		if (typeof checkData.monitorId === "string") {
+			checkData.monitorId = ObjectId.createFromHexString(checkData.monitorId);
+		}
+		const check = await DistributedUptimeCheck.findOneAndUpdate(
+			{
+				monitorId: checkData.monitorId,
+				city: checkData.city,
+			},
+			[
+				{
+					$set: {
+						...checkData,
+
+						responseTime: {
+							$cond: {
+								if: { $ifNull: ["$count", false] },
+								then: {
+									$round: [
+										{
+											$divide: [
+												{
+													$add: [
+														{ $multiply: ["$responseTime", "$count"] },
+														checkData.responseTime,
+													],
+												},
+												{ $add: ["$count", 1] },
+											],
+										},
+										2,
+									],
+								},
+								else: checkData.responseTime,
+							},
+						},
+						count: { $add: [{ $ifNull: ["$count", 0] }, 1] },
+					},
+				},
+			],
+			{
+				upsert: true,
+				new: true,
+				runValidators: true,
+			}
+		);
 		return check;
 	} catch (error) {
 		error.service = SERVICE_NAME;

--- a/db/mongo/modules/monitorModule.js
+++ b/db/mongo/modules/monitorModule.js
@@ -19,7 +19,6 @@ import {
 	buildDePINLatestChecks,
 } from "./monitorModuleQueries.js";
 import { ObjectId } from "mongodb";
-import { safelyParseFloat } from "../../../utils/dataUtils.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -393,9 +392,9 @@ const getDistributedUptimeDetailsById = async (req) => {
 			recent: "%Y-%m-%dT%H:%M:00Z",
 			day: {
 				$concat: [
-					{ $dateToString: { format: "%Y-%m-%dT%H:", date: "$createdAt" } },
+					{ $dateToString: { format: "%Y-%m-%dT%H:", date: "$updatedAt" } },
 					{
-						$cond: [{ $lt: [{ $minute: "$createdAt" }, 30] }, "00:00Z", "30:00Z"],
+						$cond: [{ $lt: [{ $minute: "$updatedAt" }, 30] }, "00:00Z", "30:00Z"],
 					},
 				],
 			},
@@ -577,6 +576,7 @@ const getMonitorById = async (monitorId) => {
 
 const getMonitorsByTeamId = async (req) => {
 	let { limit, type, page, rowsPerPage, filter, field, order } = req.query;
+
 	limit = parseInt(limit);
 	page = parseInt(page);
 	rowsPerPage = parseInt(rowsPerPage);

--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -557,7 +557,6 @@ const buildMonitorStatsPipeline = (monitor) => {
 };
 
 const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
-	console.log(JSON.stringify(dateString, null, 2));
 	return [
 		{
 			$match: {

--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -557,18 +557,19 @@ const buildMonitorStatsPipeline = (monitor) => {
 };
 
 const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
+	console.log(JSON.stringify(dateString, null, 2));
 	return [
 		{
 			$match: {
 				monitorId: monitor._id,
-				createdAt: { $gte: dates.start, $lte: dates.end },
+				updatedAt: { $gte: dates.start, $lte: dates.end },
 			},
 		},
 		{
 			$project: {
 				_id: 0,
 				city: 1,
-				createdAt: 1,
+				updatedAt: 1,
 				"location.lat": 1,
 				"location.lng": 1,
 				responseTime: 1,
@@ -598,7 +599,7 @@ const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
 								date: {
 									$dateToString: {
 										format: dateString,
-										date: "$createdAt",
+										date: "$updatedAt",
 									},
 								},
 							},
@@ -632,7 +633,7 @@ const buildDePINLatestChecks = (monitor) => {
 			},
 		},
 		{
-			$sort: { createdAt: -1 },
+			$sort: { updatedAt: -1 },
 		},
 		{
 			$limit: 5,


### PR DESCRIPTION
This PR improves how checks are handled for DePIN monitors.  Instead of creating a new check for each callback, we now only create new checks for new cities.  If a city already exists, it's data is updated with the repsonse time being averaged.
