### PR TITLE
Fix for frontend UI where the due to type being empty we are getting …

### DIFF
--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -600,6 +600,7 @@ const buildMonitorsByTeamIdPipeline = ({ matchStage, field, order }) => {
 			$project: {
 				_id: 1,
 				name: 1,
+				type: 1,
 			},
 		},
 	];


### PR DESCRIPTION
The maintenance page is calling an api 
`/api/v1/monitors/team/67c0b6f7cf5afea0e847cf01?type=http&type=ping&type=pagespeed` 
where it is expected the monitor data to contain type and this is important as this data is not filtered but the whole monitors.

Before:

https://github.com/user-attachments/assets/ee7437d2-d4c3-452d-aaad-8797d9c7e47a

After:

https://github.com/user-attachments/assets/cdd09d44-977d-49b9-8c14-4e1f32d93f5a

cc: @ajhollid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data responses by including an additional attribute, providing users with more detailed information in the results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->