### PR TITLE
fix: uptime details

### DIFF
--- a/controllers/monitorController.js
+++ b/controllers/monitorController.js
@@ -76,10 +76,10 @@ class MonitorController {
 
 	getUptimeDetailsById = async (req, res, next) => {
 		try {
-			const monitor = await this.db.getUptimeDetailsById(req);
+			const data = await this.db.getUptimeDetailsById(req);
 			return res.success({
 				msg: this.stringService.monitorGetById,
-				data: monitor,
+				data,
 			});
 		} catch (error) {
 			next(handleError(error, SERVICE_NAME, "getMonitorDetailsById"));

--- a/db/models/MonitorStats.js
+++ b/db/models/MonitorStats.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 
-const MonitorSatsSchema = new mongoose.Schema(
+const MonitorStatsSchema = new mongoose.Schema(
 	{
 		monitorId: {
 			type: mongoose.Schema.Types.ObjectId,
@@ -32,6 +32,14 @@ const MonitorSatsSchema = new mongoose.Schema(
 			type: Number,
 			default: 0,
 		},
+		lastResponseTime: {
+			type: Number,
+			default: 0,
+		},
+		timeOfLastFailure: {
+			type: Number,
+			default: 0,
+		},
 		uptBurnt: {
 			type: mongoose.Schema.Types.Decimal128,
 			required: false,
@@ -40,6 +48,6 @@ const MonitorSatsSchema = new mongoose.Schema(
 	{ timestamps: true }
 );
 
-const MonitorSats = mongoose.model("MonitorStats", MonitorSatsSchema);
+const MonitorStats = mongoose.model("MonitorStats", MonitorStatsSchema);
 
-export default MonitorSats;
+export default MonitorStats;

--- a/db/mongo/modules/monitorModule.js
+++ b/db/mongo/modules/monitorModule.js
@@ -340,11 +340,6 @@ const getUptimeDetailsById = async (req) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
 	try {
 		const { monitorId } = req.params;
-		const monitor = await Monitor.findById(monitorId);
-		if (monitor === null || monitor === undefined) {
-			throw new Error(stringService.dbFindMonitorById(monitorId));
-		}
-
 		const { dateRange, normalize } = req.query;
 		const dates = getDateRange(dateRange);
 		const formatLookup = {
@@ -357,7 +352,7 @@ const getUptimeDetailsById = async (req) => {
 		const dateString = formatLookup[dateRange];
 
 		const results = await Check.aggregate(
-			buildUptimeDetailsPipeline(monitor, dates, dateString)
+			buildUptimeDetailsPipeline(monitorId, dates, dateString)
 		);
 
 		const monitorData = results[0];
@@ -367,13 +362,9 @@ const getUptimeDetailsById = async (req) => {
 			100
 		);
 
-		const monitorStats = {
-			...monitor.toObject(),
-			...monitorData,
-			groupedChecks: normalizedGroupChecks,
-		};
-
-		return monitorStats;
+		monitorData.groupedChecks = normalizedGroupChecks;
+		const monitorStats = await MonitorStats.findOne({ monitorId });
+		return { monitorData, monitorStats };
 	} catch (error) {
 		error.service = SERVICE_NAME;
 		error.method = "getUptimeDetailsById";

--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -1,10 +1,11 @@
 import { ObjectId } from "mongodb";
 
-const buildUptimeDetailsPipeline = (monitor, dates, dateString) => {
+const buildUptimeDetailsPipeline = (monitorId, dates, dateString) => {
 	return [
 		{
 			$match: {
-				monitorId: monitor._id,
+				monitorId: ObjectId.createFromHexString(monitorId),
+				createdAt: { $gte: dates.start, $lte: dates.end },
 			},
 		},
 		{
@@ -14,73 +15,42 @@ const buildUptimeDetailsPipeline = (monitor, dates, dateString) => {
 		},
 		{
 			$facet: {
-				aggregateData: [
+				// For the response time chart, should return checks for date window
+				// Grouped by: {day: hour}, {week: day}, {month: day}
+				uptimePercentage: [
+					{
+						$group: {
+							_id: null,
+							upChecks: {
+								$sum: { $cond: [{ $eq: ["$status", true] }, 1, 0] },
+							},
+							totalChecks: { $sum: 1 },
+						},
+					},
+					{
+						$project: {
+							_id: 0,
+							percentage: {
+								$cond: [
+									{ $eq: ["$totalChecks", 0] },
+									0,
+									{ $divide: ["$upChecks", "$totalChecks"] },
+								],
+							},
+						},
+					},
+				],
+				groupedAvgResponseTime: [
 					{
 						$group: {
 							_id: null,
 							avgResponseTime: {
 								$avg: "$responseTime",
 							},
-							lastCheck: {
-								$last: "$$ROOT",
-							},
-							totalChecks: {
-								$sum: 1,
-							},
 						},
 					},
 				],
-				uptimeStreak: [
-					{
-						$sort: {
-							createdAt: -1,
-						},
-					},
-					{
-						$group: {
-							_id: null,
-							checks: { $push: "$$ROOT" },
-						},
-					},
-					{
-						$project: {
-							streak: {
-								$reduce: {
-									input: "$checks",
-									initialValue: { checks: [], foundFalse: false },
-									in: {
-										$cond: [
-											{
-												$and: [
-													{ $not: "$$value.foundFalse" }, // stop reducing if a false check has been found
-													{ $eq: ["$$this.status", true] }, // continue reducing if current check true
-												],
-											},
-											// true case
-											{
-												checks: { $concatArrays: ["$$value.checks", ["$$this"]] },
-												foundFalse: false, // Add the check to the streak
-											},
-											// false case
-											{
-												checks: "$$value.checks",
-												foundFalse: true, // Mark that we found a false
-											},
-										],
-									},
-								},
-							},
-						},
-					},
-				],
-				// For the response time chart, should return checks for date window
-				// Grouped by: {day: hour}, {week: day}, {month: day}
 				groupedChecks: [
-					{
-						$match: {
-							createdAt: { $gte: dates.start, $lte: dates.end },
-						},
-					},
 					{
 						$group: {
 							_id: {
@@ -103,48 +73,11 @@ const buildUptimeDetailsPipeline = (monitor, dates, dateString) => {
 						},
 					},
 				],
-				// Average response time for the date window
-				groupAvgResponseTime: [
-					{
-						$match: {
-							createdAt: { $gte: dates.start, $lte: dates.end },
-						},
-					},
-					{
-						$group: {
-							_id: null,
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-						},
-					},
-				],
-				// All UpChecks for the date window
-				upChecks: [
-					{
-						$match: {
-							status: true,
-							createdAt: { $gte: dates.start, $lte: dates.end },
-						},
-					},
-					{
-						$group: {
-							_id: null,
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-							totalChecks: {
-								$sum: 1,
-							},
-						},
-					},
-				],
 				// Up checks grouped by: {day: hour}, {week: day}, {month: day}
 				groupedUpChecks: [
 					{
 						$match: {
 							status: true,
-							createdAt: { $gte: dates.start, $lte: dates.end },
 						},
 					},
 					{
@@ -167,32 +100,11 @@ const buildUptimeDetailsPipeline = (monitor, dates, dateString) => {
 						$sort: { _id: 1 },
 					},
 				],
-				// All down checks for the date window
-				downChecks: [
-					{
-						$match: {
-							status: false,
-							createdAt: { $gte: dates.start, $lte: dates.end },
-						},
-					},
-					{
-						$group: {
-							_id: null,
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-							totalChecks: {
-								$sum: 1,
-							},
-						},
-					},
-				],
 				// Down checks grouped by: {day: hour}, {week: day}, {month: day} for the date window
 				groupedDownChecks: [
 					{
 						$match: {
 							status: false,
-							createdAt: { $gte: dates.start, $lte: dates.end },
 						},
 					},
 					{
@@ -218,64 +130,41 @@ const buildUptimeDetailsPipeline = (monitor, dates, dateString) => {
 			},
 		},
 		{
+			$lookup: {
+				from: "monitors",
+				let: { monitor_id: { $toObjectId: monitorId } },
+				pipeline: [
+					{
+						$match: {
+							$expr: { $eq: ["$_id", "$$monitor_id"] },
+						},
+					},
+					{
+						$project: {
+							_id: 1,
+							name: 1,
+							status: 1,
+							interval: 1,
+							type: 1,
+							url: 1,
+							isActive: 1,
+						},
+					},
+				],
+				as: "monitor",
+			},
+		},
+		{
 			$project: {
-				uptimeStreak: {
-					$let: {
-						vars: {
-							checks: { $ifNull: [{ $first: "$uptimeStreak.streak.checks" }, []] },
-						},
-						in: {
-							$cond: [
-								{ $eq: [{ $size: "$$checks" }, 0] },
-								0,
-								{
-									$subtract: [new Date(), { $last: "$$checks.createdAt" }],
-								},
-							],
-						},
-					},
-				},
-				avgResponseTime: {
-					$arrayElemAt: ["$aggregateData.avgResponseTime", 0],
-				},
-				totalChecks: {
-					$arrayElemAt: ["$aggregateData.totalChecks", 0],
-				},
-				latestResponseTime: {
-					$arrayElemAt: ["$aggregateData.lastCheck.responseTime", 0],
-				},
-				timeSinceLastCheck: {
-					$let: {
-						vars: {
-							lastCheck: {
-								$arrayElemAt: ["$aggregateData.lastCheck", 0],
-							},
-						},
-						in: {
-							$cond: [
-								{
-									$ifNull: ["$$lastCheck", false],
-								},
-								{
-									$subtract: [new Date(), "$$lastCheck.createdAt"],
-								},
-								0,
-							],
-						},
-					},
-				},
-				groupedChecks: "$groupedChecks",
 				groupedAvgResponseTime: {
-					$arrayElemAt: ["$groupAvgResponseTime", 0],
+					$arrayElemAt: ["$groupedAvgResponseTime.avgResponseTime", 0],
 				},
-				upChecks: {
-					$arrayElemAt: ["$upChecks", 0],
-				},
+
+				groupedChecks: "$groupedChecks",
 				groupedUpChecks: "$groupedUpChecks",
-				downChecks: {
-					$arrayElemAt: ["$downChecks", 0],
-				},
 				groupedDownChecks: "$groupedDownChecks",
+				groupedUptimePercentage: { $arrayElemAt: ["$uptimePercentage.percentage", 0] },
+				monitor: { $arrayElemAt: ["$monitor", 0] },
 			},
 		},
 	];

--- a/service/statusService.js
+++ b/service/statusService.js
@@ -39,6 +39,9 @@ class StatusService {
 
 			// Update stats
 
+			// Last response time
+			stats.lastResponseTime = responseTime;
+
 			// Avg response time:
 			let avgResponseTime = stats.avgResponseTime;
 			if (typeof responseTime !== "undefined" && responseTime !== null) {
@@ -56,8 +59,13 @@ class StatusService {
 			stats.totalChecks++;
 			if (status === true) {
 				stats.totalUpChecks++;
+				// Update the timeSinceLastFailure if needed
+				if (stats.timeOfLastFailure === 0) {
+					stats.timeOfLastFailure = new Date().getTime();
+				}
 			} else {
 				stats.totalDownChecks++;
+				stats.timeOfLastFailure = 0;
 			}
 
 			// Calculate uptime percentage


### PR DESCRIPTION
This PR improves the Uptime Details query pipeline

1.  Add `timeOfLastFailure` and `lastResponseTime` to the running stats, eliminates need to calculate
2. Simplify DB query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced uptime monitoring now displays a computed uptime percentage along with detailed performance metrics, providing clearer insights into response times and service reliability.

- **Refactor**
  - Streamlined the data delivery for uptime details to ensure a more consistent and reliable presentation of monitoring statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->