### PR TITLE
Fix: Limit Redis Connection Request

### DIFF
--- a/service/jobQueue.js
+++ b/service/jobQueue.js
@@ -14,6 +14,9 @@ const QUEUE_LOOKUP = {
 	distributed_http: "distributed",
 };
 const getSchedulerId = (monitor) => `scheduler:${monitor.type}:${monitor._id}`;
+const MAX_RETRIES = 3;
+const MAX_DELAY = 3000;
+const BASE_DELAY = 1000;
 
 class NewJobQueue {
 	static SERVICE_NAME = SERVICE_NAME;
@@ -31,7 +34,17 @@ class NewJobQueue {
 	) {
 		const settings = settingsService.getSettings() || {};
 		const { redisUrl } = settings;
-		const connection = new IORedis(redisUrl, { maxRetriesPerRequest: null });
+		const connection = new IORedis(redisUrl, { 
+			maxRetriesPerRequest: null,
+			retryStrategy: (attempts) => {
+				if (attempts > MAX_RETRIES) {
+					console.error("Max Redis connection retries reached.")
+					connection.quit();
+				}
+				const delay = Math.min(attempts * BASE_DELAY, MAX_DELAY);
+				return delay;
+			}
+		});
 
 		this.queues = {};
 		this.workers = {};

--- a/service/jobQueue.js
+++ b/service/jobQueue.js
@@ -33,12 +33,19 @@ class NewJobQueue {
 		Worker
 	) {
 		const settings = settingsService.getSettings() || {};
+		this.logger = logger;
 		const { redisUrl } = settings;
 		const connection = new IORedis(redisUrl, { 
 			maxRetriesPerRequest: null,
 			retryStrategy: (attempts) => {
 				if (attempts > MAX_RETRIES) {
-					console.error("Max Redis connection retries reached.")
+					const error = new Error("Max Redis connection retries reached.");
+					this.logger.error({
+						message: "Max Redis connection retries reached.",
+						service: SERVICE_NAME,
+						method: "constructor",
+						stack: error.stack,
+					});
 					connection.quit();
 				}
 				const delay = Math.min(attempts * BASE_DELAY, MAX_DELAY);
@@ -56,7 +63,6 @@ class NewJobQueue {
 		this.statusService = statusService;
 		this.notificationService = notificationService;
 		this.settingsService = settingsService;
-		this.logger = logger;
 		this.Worker = Worker;
 		this.stringService = stringService;
 


### PR DESCRIPTION
### Description

This PR address the issue of unlimited connection requests from `Backend` server to `Redis`, when Redis is down. In production level, this will create an unnecessary load on the system. Hence, the limiting. 

### Fixes

#57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced connection reliability by refining the retry mechanism for managing connection attempts, leading to more stable service performance.
  - Introduced constants to control the maximum number of retries and delay intervals for connection attempts, improving error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->