### PR TITLE
feat:  add filtering by `isActive` and `type` properties

### DIFF
--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -562,11 +562,23 @@ const buildMonitorsWithChecksByTeamIdPipeline = ({
 	const skip = page && rowsPerPage ? page * rowsPerPage : 0;
 	const sort = { [field]: order === "asc" ? 1 : -1 };
 	const limitStage = rowsPerPage ? [{ $limit: rowsPerPage }] : [];
-	if (typeof filter !== "undefined") {
+
+	// Match name
+	if (typeof filter !== "undefined" && field === "name") {
 		matchStage.$or = [
 			{ name: { $regex: filter, $options: "i" } },
 			{ url: { $regex: filter, $options: "i" } },
 		];
+	}
+
+	// Match isActive
+	if (typeof filter !== "undefined" && field === "isActive") {
+		matchStage.isActive = filter === "true" ? true : false;
+	}
+
+	// Match type
+	if (typeof filter !== "undefined" && field === "type") {
+		matchStage.type = filter;
 	}
 
 	const monitorsPipeline = [


### PR DESCRIPTION
This PR adds filtering options for `isActive` and `type` to facilitae issue [1990](https://github.com/bluewave-labs/Checkmate/issues/1990)

Example query:

```
http://localhost:5000/api/v1/monitors/team/67b4cbb8439ada9d698ed453/with-checks?limit=25&type=http&type=ping&type=docker&type=port&rowsPerPage=10&field=isActive&filter=false
```

`field` and `filter` are the two properties to use here, `field` being the field to filter by and `filter` being the value to filter by.