### PR TITLE
Feat: Add Status Filtering Support in BE

### DIFF
--- a/db/mongo/modules/monitorModuleQueries.js
+++ b/db/mongo/modules/monitorModuleQueries.js
@@ -576,6 +576,10 @@ const buildMonitorsWithChecksByTeamIdPipeline = ({
 		matchStage.isActive = filter === "true" ? true : false;
 	}
 
+	if (typeof filter !== "undefined" && field === "status") {
+		matchStage.status = filter === "true" ? true : false;
+	}
+
 	// Match type
 	if (typeof filter !== "undefined" && field === "type") {
 		matchStage.type = filter;


### PR DESCRIPTION
This PR address the support for status as a filter in uptime monitors.

Example Query:
`http://localhost:5000/api/v1/monitors/team/67cf3394baa29eefae5809f4/with-checks limit=25&type=http&rowsPerPage=10&field=status&filter=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced monitor filtering by incorporating status-based criteria alongside existing filters for name, active state, and type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->