### PR TITLE
fix: safe property access in setting service, restore buffer time

### DIFF
--- a/service/bufferService.js
+++ b/service/bufferService.js
@@ -1,5 +1,5 @@
 const SERVICE_NAME = "BufferService";
-const BUFFER_TIMEOUT = 1000 * 60 * 0.5; // 1 minute
+const BUFFER_TIMEOUT = 1000 * 60 * 1; // 1 minute
 const TYPE_MAP = {
 	http: "checks",
 	ping: "checks",

--- a/service/settingsService.js
+++ b/service/settingsService.js
@@ -49,7 +49,10 @@ class SettingsService {
 
 			// If there are any settings that weren't set by environment variables, use user settings from DB
 			for (const key in envConfig) {
-				if (envConfig[key] === undefined && dbSettings[key] !== undefined) {
+				if (
+					typeof envConfig?.[key] === "undefined" &&
+					typeof dbSettings?.[key] !== "undefined"
+				) {
 					this.settings[key] = dbSettings[key];
 				}
 			}


### PR DESCRIPTION
This PR adds safe property access to settings objects in the SettingsService.

It also resets the buffer flush time to one minute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the timing for background processes, extending the interval from 30 seconds to 60 seconds for smoother operations.
  
- **Refactor**
  - Refined the configuration checking logic to enhance reliability and prevent potential inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->